### PR TITLE
Rename max/min reduction to avoid overloading Python built-in functions

### DIFF
--- a/tests/test_pretrained_models.py
+++ b/tests/test_pretrained_models.py
@@ -10,8 +10,6 @@ from tensorflow.core.framework import graph_pb2
 import coremltools
 import tfcoreml as tf_converter
 
-from nose.tools import set_trace
-
 TMP_MODEL_DIR = '/tmp/tfcoreml'
 TEST_IMAGE = './test_images/beach.jpg' 
 

--- a/tfcoreml/_layers.py
+++ b/tfcoreml/_layers.py
@@ -555,13 +555,13 @@ def greater(op, context):
       output_name, 'SIGMOID_HARD', input_name, output_name, params=[alpha, beta])
   context.translated[output_name] = True
 
-def sum(op, context):
+def reduce_sum(op, context):
   ss_layers._add_reduce(op, context, 'sum')
 
-def max(op, context):
+def reduce_max(op, context):
   ss_layers._add_reduce(op, context, 'max')
 
-def min(op, context):
+def reduce_min(op, context):
   ss_layers._add_reduce(op, context, 'min')
 
 def product(op, context):

--- a/tfcoreml/_ops_to_layers.py
+++ b/tfcoreml/_ops_to_layers.py
@@ -38,9 +38,9 @@ _OP_REGISTERY = {
     'MirrorPad': _layers.mirror_pad,
     'Mean': _layers.mean, # TODO - there're unsupported configurations
     'Prod': _layers.product, # TODO - there're unsupported configurations
-    'Sum': _layers.sum, # TODO - there're unsupported configurations
-    'Max': _layers.max, # TODO - there're unsupported configurations
-    'Min': _layers.min, # TODO - there're unsupported configurations
+    'Sum': _layers.reduce_sum, # TODO - there're unsupported configurations
+    'Max': _layers.reduce_max, # TODO - there're unsupported configurations
+    'Min': _layers.reduce_min, # TODO - there're unsupported configurations
     'Greater': _layers.greater, # TODO - only works for x > c where c is const
     'Const': _layers.constant,
     'Softmax': _layers.softmax,


### PR DESCRIPTION
If you use max() and min() as function names you'll overload Python's own max() and min() function, so any function trying to use Python max() and min() functions would be redirected to wrong function and fail. 
