### PR TITLE
Ensure checkpoints directory exists

### DIFF
--- a/examples/linear_mnist_train.py
+++ b/examples/linear_mnist_train.py
@@ -1,3 +1,4 @@
+import os
 import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data # Import MINST data
 
@@ -63,7 +64,11 @@ def train():
       if (epoch+1) % display_step == 0:
         print "Epoch:", '%04d' % (epoch+1), "cost=", "{:.9f}".format(avg_cost)
     print 'Training Done. Now save the checkpoint...'
-    save_path = saver.save(sess, "./checkpoints/model.ckpt")
+    save_dir = './checkpoints'
+    save_path = os.path.join(save_dir, 'model.ckpt')
+    if not os.path.exists(save_dir):
+      os.mkdir(save_dir)
+    save_path = saver.save(sess, save_path)
     tf.train.write_graph(sess.graph, './', 'model.pbtxt')
 
 


### PR DESCRIPTION
This adds a check for a 'checkpoints' directory and creates it if it doesn't exist before asking TF to save. Without this the example fails.