### PR TITLE
Proper handling of SpaceToBatch and BatchToSpace ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ List of TensorFlow ops that are supported currently (see `tfcoreml/_ops_to_layer
 * ArgMax
 * AvgPool
 * BatchNormWithGlobalNormalization
+* BatchToSpaceND*
 * BiasAdd
 * ConcatV2, Concat
 * Const
@@ -121,6 +122,7 @@ List of TensorFlow ops that are supported currently (see `tfcoreml/_ops_to_layer
 * Sigmoid
 * Slice
 * Softmax
+* SpaceToBatchND*
 * Square
 * SquaredDifference
 * StridedSlice

--- a/tfcoreml/_ops_to_layers.py
+++ b/tfcoreml/_ops_to_layers.py
@@ -13,8 +13,8 @@ _OP_REGISTRY = {
     'Equal' : _layers.skip,
     'All' : _layers.skip,
     'Pack' : _layers.skip, # TODO - need to handle it better
-    'SpaceToBatchND':_layers.skip,
-    'BatchToSpaceND':_layers.skip,
+    'SpaceToBatchND':_layers.space_to_batch,
+    'BatchToSpaceND':_layers.batch_to_space,
     'ConcatV2' : _layers.concat,
     'GreaterEqual' : _layers.greater, # TODO - need to handle it better
     'LogicalAnd' : _layers.mul, # TODO - need to handle it better


### PR DESCRIPTION
This PR:
- instead of directly skipping, checks that SpaceToBatch and BatchToSpace ops are part of a dilated convolution, only then they are converted, otherwise an error is raised since CoreML cannot handle them currently in isolation
- properly handles the padding and cropping operations hidden in these ops. These were ignored before. 