### PR TITLE
Add support to resize_bilinear used as upsample

### DIFF
--- a/tests/test_tf_converter.py
+++ b/tests/test_tf_converter.py
@@ -529,7 +529,6 @@ class TFSingleLayersTest(TFNetworkTest):
           name="test_conv2d_resize_bl/input")
       conv1 = tf.layers.conv2d(inputs=x_image, filters=3, kernel_size=[3,3],
           padding='same', activation=tf.nn.relu)
-      #size_tensor = tf.constant
       bl1 = tf.image.resize_bilinear(images=conv1, size=[32,32])
 
     output_name = [bl1.op.name]

--- a/tests/test_tf_converter.py
+++ b/tests/test_tf_converter.py
@@ -522,6 +522,19 @@ class TFSingleLayersTest(TFNetworkTest):
     self._test_tf_model(graph,
         {"test_conv1d_maxpool/input:0":[1,8,3]}, output_name, delta=1e-2)
 
+  def test_conv2d_resize_bilinear(self):
+    graph = tf.Graph()
+    with graph.as_default() as g:
+      x_image = tf.placeholder(tf.float32, shape=[None,16,16,3],
+          name="test_conv2d_resize_bl/input")
+      conv1 = tf.layers.conv2d(inputs=x_image, filters=3, kernel_size=[3,3],
+          padding='same', activation=tf.nn.relu)
+      #size_tensor = tf.constant
+      bl1 = tf.image.resize_bilinear(images=conv1, size=[32,32])
+
+    output_name = [bl1.op.name]
+    self._test_tf_model(graph,
+        {"test_conv2d_resize_bl/input:0":[1,16,16,3]}, output_name, delta=1e-2)
 
 class TFSlimTest(TFNetworkTest):
   """Small models for tf.slim layers

--- a/tfcoreml/_ops_to_layers.py
+++ b/tfcoreml/_ops_to_layers.py
@@ -32,6 +32,7 @@ _OP_REGISTRY = {
     'Transpose': _layers.transpose, # TODO - only works 4D tensors
     'Sigmoid': _layers.sigmoid,
     'ResizeNearestNeighbor': _layers.resize_nearest_neighbor,
+    'ResizeBilinear': _layers.resize_bilinear,
     'Square': _layers.square,
     'SquaredDifference': _layers.squared_difference,
     'Pad' : _layers.pad,


### PR DESCRIPTION
This PR adds support of TensorFlow op, resize_bilinear, when the output sizes are an integer multiple of the input size (equivalent to upsampling)

