### PR TITLE
Add support for sqrt und pow operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ List of TensorFlow ops that are supported currently (see `tfcoreml/_ops_to_layer
 * OneHot
 * Pad
 * Placeholder
+* Pow
 * Prod*
 * RandomUniform*
 * RealDiv
@@ -128,6 +129,7 @@ List of TensorFlow ops that are supported currently (see `tfcoreml/_ops_to_layer
 * SpaceToBatchND*
 * Square
 * SquaredDifference
+* Sqrt
 * StridedSlice
 * Sub
 * Sum*

--- a/tfcoreml/_layers.py
+++ b/tfcoreml/_layers.py
@@ -860,6 +860,24 @@ def square(op, context):
   context.builder.add_elementwise(
       output_name, [input_name, input_name], output_name, 'MULTIPLY')
 
+def pow(op, context):
+
+  input_name = compat.as_bytes(op.inputs[0].name)
+  output_name = compat.as_bytes(op.outputs[0].name)
+
+  context.translated[output_name] = True
+  context.builder.add_unary(
+    output_name, input_name, output_name, 'power')
+
+def sqrt(op, context):
+
+  input_name = compat.as_bytes(op.inputs[0].name)
+  output_name = compat.as_bytes(op.outputs[0].name)
+
+  context.translated[output_name] = True
+  context.builder.add_unary(
+    output_name, input_name, output_name, 'sqrt')
+
 def resize_nearest_neighbor(op, context):
 
   input_name = compat.as_bytes(op.inputs[0].name)

--- a/tfcoreml/_ops_to_layers.py
+++ b/tfcoreml/_ops_to_layers.py
@@ -49,6 +49,8 @@ _OP_REGISTRY = {
     'Relu': _layers.relu,
     'QuantizedRelu': _layers.relu,
     'Rsqrt': _layers.rsqrt,
+    'Sqrt': _layers.sqrt,
+    'Pow': _layers.pow,
     'Add': _layers.add,
     'Sub': _layers.sub,
     'Mul': _layers.mul,


### PR DESCRIPTION
Hey, I needed support for `tf.sqrt` and `tf.pow` during conversion. So I added both operations and updated the mapping and readme. My conversion seems to work fine now. If I missed anything, please let me know and I'll update accordingly :)