### PR TITLE
Concat with constants

### DIFF
--- a/tfcoreml/_shape_sensitive_layers.py
+++ b/tfcoreml/_shape_sensitive_layers.py
@@ -97,6 +97,7 @@ def _add_concat(op, context):
       if i == 0:
         continue
       input_names.append(compat.as_bytes(input.name))
+      _layers.make_tensor(input, context)
 
   if op.type == 'ConcatV2':
     axis_name = compat.as_bytes(op.inputs[-1].name)
@@ -106,6 +107,7 @@ def _add_concat(op, context):
       if i == len(op.inputs) - 1:
         continue
       input_names.append(compat.as_bytes(input.name))
+      _layers.make_tensor(input, context)
 
   if context.use_dfs_shape_infer:
     status = interpret_shape(output_name, context)


### PR DESCRIPTION
This fixes a bug which causes incorrect conversion of concat layer when one or more of its input is a constant. 
Also, some  rearrangements in the unit test file to be able to test a TF graph with no variables. 
A unittest with concat layer is also added.