### PR TITLE
 For supported ops, fixed an issue while using op.type as key within custom_conversion_functions

### DIFF
--- a/examples/inception_v1_preprocessing_steps.ipynb
+++ b/examples/inception_v1_preprocessing_steps.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# Download the model and class label package\n",
     "from __future__ import print_function\n",
-    "import urllib, os, sys\n",
+    "import  os, sys\n",
     "import tarfile"
    ]
   },
@@ -47,6 +47,7 @@
     "\n",
     "    if not os.path.exists(fpath):\n",
     "        if sys.version_info[0] < 3:\n",
+    "            import urllib\n",
     "            urllib.urlretrieve(url, fpath)\n",
     "        else:\n",
     "            import urllib.request\n",
@@ -319,21 +320,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/examples/inception_v3.ipynb
+++ b/examples/inception_v3.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
     "https://storage.googleapis.com/download.tensorflow.org/models/inception_dec_2015.zip\n",
     "\"\"\"\n",
     "from __future__ import print_function\n",
-    "import urllib, os, sys, zipfile\n",
+    "import  os, sys, zipfile\n",
     "from os.path import dirname\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,6 +49,7 @@
     "\n",
     "    if not os.path.exists(fpath):\n",
     "        if sys.version_info[0] < 3:\n",
+    "            import urllib\n",
     "            urllib.urlretrieve(url, fpath)\n",
     "        else:\n",
     "            import urllib.request\n",
@@ -213,21 +214,21 @@
  "metadata": {
   "celltoolbar": "Raw Cell Format",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/examples/ssd_example.ipynb
+++ b/examples/ssd_example.ipynb
@@ -24,7 +24,7 @@
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
-    "import urllib, os, sys, zipfile\n",
+    "import os, sys, zipfile\n",
     "from os.path import dirname\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
@@ -44,6 +44,7 @@
     "    os.makedirs(example_dir)\n",
     "mobilenet_ssd_fpath = example_dir + 'ssd_mobilenet_v1_android_export.zip'\n",
     "if sys.version_info[0] < 3:\n",
+    "    import urllib\n",
     "    urllib.urlretrieve(mobilenet_ssd_url, mobilenet_ssd_fpath)\n",
     "else:\n",
     "    import urllib.request\n",
@@ -266,21 +267,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/examples/style_transfer_example.ipynb
+++ b/examples/style_transfer_example.ipynb
@@ -25,7 +25,6 @@
     "from __future__ import print_function\n",
     "import coremltools\n",
     "import os,sys\n",
-    "import urllib\n",
     "import zipfile\n",
     "def download_file_and_unzip(url, dir_path='.'):\n",
     "    \"\"\"Download the frozen TensorFlow model and unzip it.\n",
@@ -40,6 +39,7 @@
     "\n",
     "    if not os.path.exists(fpath):\n",
     "        if sys.version_info[0] < 3:\n",
+    "            import urllib\n",
     "            urllib.urlretrieve(url, fpath)\n",
     "        else:\n",
     "            import urllib.request\n",
@@ -379,21 +379,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/tests/test_tf_converter.py
+++ b/tests/test_tf_converter.py
@@ -1037,15 +1037,17 @@ class TFCustomLayerTest(TFNetworkTest):
       y = tf.slice(y, begin=[0, 1, 1, 1], size=[1, 2, 2, 2], name='output')
 
     output_name = [y.op.name]
-    coreml_model = self._test_tf_model(graph,
-                                       {"input:0": [1, 10,10, 3]},
-                                       output_name,
-                                       check_numerical_accuracy=False,
-                                       add_custom_layers=True,
-                                       custom_conversion_functions={'output': _convert_slice})
+    
+    for key in [y.op.name, y.op.type]:
+        coreml_model = self._test_tf_model(graph,
+                                           {"input:0": [1, 10,10, 3]},
+                                           output_name,
+                                           check_numerical_accuracy=False,
+                                           add_custom_layers=True,
+                                           custom_conversion_functions={key: _convert_slice})
 
-    spec = coreml_model.get_spec()
-    layers = spec.neuralNetwork.layers
-    self.assertIsNotNone(layers[1].custom)
-    self.assertEqual('Slice', layers[1].custom.className)
-    self.assertEqual(2, len(layers[1].custom.weights))
+        spec = coreml_model.get_spec()
+        layers = spec.neuralNetwork.layers
+        self.assertIsNotNone(layers[1].custom)
+        self.assertEqual('Slice', layers[1].custom.className)
+        self.assertEqual(2, len(layers[1].custom.weights))

--- a/tests/test_tf_keras_layers.py
+++ b/tests/test_tf_keras_layers.py
@@ -21,7 +21,7 @@ if HAS_KERAS2_TF:
   from keras.layers import ZeroPadding2D, UpSampling2D, Cropping2D
   from keras.layers import ZeroPadding1D, UpSampling1D, Cropping1D
   from keras.layers.core import SpatialDropout1D, SpatialDropout2D
-  from keras.applications.mobilenet import DepthwiseConv2D    
+  from keras.layers import DepthwiseConv2D    
    
 def _tf_transpose(x, is_sequence=False):
   if not hasattr(x, "shape"):

--- a/tfcoreml/_ops_to_layers.py
+++ b/tfcoreml/_ops_to_layers.py
@@ -162,7 +162,7 @@ def convert_ops_to_layers(context):
         translator = _layers.skip
       elif op.type in _OP_REGISTRY:
         check(op, context)
-        if context.add_custom_layers and op.name in context.custom_conversion_functions:
+        if context.add_custom_layers and (op.name in context.custom_conversion_functions or op.type in context.custom_conversion_functions):
           translator = _layers_common.custom_layer
         else:
           translator = _get_translator_function(op.type)


### PR DESCRIPTION
**Issues:**
Fixed an issue when using op.type of a supported op as key within custom_conversion_functions and added a unit test

**Minor Updates:**
- Changed import command for "DepthwiseConv2D" layer in file [test_tf_keras_layers.py](https://github.com/tf-coreml/tf-coreml/blob/master/tests/test_tf_keras_layers.py) 
- For ipython notebook examples with python2 kernel, resolved referencing error related to urllib by shifting down the import statement.
