### PR TITLE
Fix error of TypeError: object of type 'map' has no len()

### DIFF
--- a/tfcoreml/_layers.py
+++ b/tfcoreml/_layers.py
@@ -1021,7 +1021,7 @@ def transpose(op, context):
 
   coreml_axes = map(translate_transpose, target_idx)
 
-  context.builder.add_permute(output_name, coreml_axes, input_name, output_name)
+  context.builder.add_permute(output_name, list(coreml_axes), input_name, output_name)
   context.translated[output_name] = True
 
 def real_div(op, context):


### PR DESCRIPTION
In Python3, we convert shuffleseg model and find that we meet the error. Then find that `coreml_axes` is `map` object, but coremltools api require it is list.