### PR TITLE
Add functionality for LeakyRelu ops introduced in Tensorflow 1.13

### DIFF
--- a/tests/test_tf_converter.py
+++ b/tests/test_tf_converter.py
@@ -795,8 +795,9 @@ class TFSingleLayersTest(TFNetworkTest):
       z = tf.nn.leaky_relu(x_input, 0.2, name='output')
 
     output_name = [z.op.name]
-    self._test_tf_model_constant(graph,
-        {"input:0":[1,5,5,6]}, output_name, delta=1e-2)
+    self._test_tf_model_constant(graph, {"input:0":[1,5,5,6]},
+                                 output_name, delta=1e-2,
+                                 data_mode="random_zero_mean")
 
   def test_resize_bilinear_non_fractional(self):
     graph = tf.Graph()

--- a/tfcoreml/_interpret_shapes.py
+++ b/tfcoreml/_interpret_shapes.py
@@ -168,6 +168,7 @@ _SHAPE_TRANSLATOR_REGISTRY = {
     'Softmax': _identity,
     'Relu6': _identity,
     'Relu': _identity,
+    'LeakyRelu': _identity,
     'QuantizedRelu': _identity,
     'DepthwiseConv2dNative': _identity,
     'MaxPool': _identity,
@@ -264,5 +265,3 @@ def _interpret_and_label_shapes(blob_name, context, tracking_dict):
 
 def _interpret_shape(blob_name, context):
     return _interpret_and_label_shapes(blob_name, context, tracking_dict={})
-
-

--- a/tfcoreml/_layers.py
+++ b/tfcoreml/_layers.py
@@ -683,6 +683,14 @@ def relu(op, context):
     context.translated[op.outputs[1].name] = True
     context.translated[op.outputs[2].name] = True
 
+def leaky_relu(op, context):
+  input_name = make_tensor(op.inputs[0], context)
+  alpha = op.get_attr('alpha')
+  output_name = compat.as_str_any(op.outputs[0].name)
+  context.builder.add_activation(output_name, 'LEAKYRELU', input_name,
+                                 output_name, [alpha])
+  context.translated[output_name] = True
+
 def exp(op, context):
   input_name = make_tensor(op.inputs[0], context)
   output_name = compat.as_str_any(op.outputs[0].name)

--- a/tfcoreml/_ops_to_layers.py
+++ b/tfcoreml/_ops_to_layers.py
@@ -24,6 +24,7 @@ _CORE_OPS = {
   'ExtractImagePatches': _layers.extract_image_patches,
   'FusedBatchNorm': _layers.batchnorm,
   'Identity': _layers.identity,
+  'LeakyRelu': _layers.leaky_relu,
   'Log': _layers.log,
   'LRN': _layers.lrn,
   'Max': _layers.reduce_max,  # TODO - there're unsupported configurations


### PR DESCRIPTION
Allow tf-coreml to export models containing leaky_relu in tensorflow versions
which have the following commit: [https://github.com/tensorflow/tensorflow/commit/4e72dd865a3fc83baa69f6b7c08720a1b546a464](https://github.com/tensorflow/tensorflow/commit/4e72dd865a3fc83baa69f6b7c08720a1b546a464)
Use Core ML LEAKYRELU activation

- Add LeakyRelu op mapped to _layers.leaky_relu
- Change leaky_relu test to use zero-mean random numbers