### PR TITLE
Remove tf.reset_default_graph()

### DIFF
--- a/tfcoreml/_tf_coreml_converter.py
+++ b/tfcoreml/_tf_coreml_converter.py
@@ -211,7 +211,6 @@ def _convert_pb_to_mlmodel(tf_model_path,
   with open(tf_model_path, 'rb') as f:
     serialized = f.read()
 
-  tf.reset_default_graph()
   gdef = tf.GraphDef()
   gdef.ParseFromString(serialized)
 


### PR DESCRIPTION
This call is unnecessary and can have unexpected consequences for the user.